### PR TITLE
Support mode=json for model_dump

### DIFF
--- a/pydantic_client/decorators.py
+++ b/pydantic_client/decorators.py
@@ -75,7 +75,7 @@ def _process_request_params(
     for param_name, param_value in params.items():
         if isinstance(param_value, BaseModel):
             if method in ["POST", "PUT", "PATCH"]:
-                body_data = param_value.model_dump()
+                body_data = param_value.model_dump(mode='json')
 
     info = {
         "method": method,


### PR DESCRIPTION
The current implementation in [pydantic_client/decorators.py:78] uses param_value.model_dump() without specifying the serialization mode, which fails to handle non-JSON-serializable types like UUID objects. This causes TypeError: Object of type UUID is not JSON serializable when making HTTP requests with models containing UUID fields.